### PR TITLE
Fixups

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,8 +23,8 @@
 	<body>
 		<header>
 			<h1>
-				<a href="/"><img src="/images/logo.svg" height="40" alt="{{ site.title }} logo"></a>
 				<button type="button" class="open-nav" id="open-nav"></button>
+				<a href="/"><img src="/images/logo.svg" height="40" alt="{{ site.title }} logo"></a>
 			</h1>
 
 			<form action="/search/" method="get">

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -29,7 +29,7 @@ html {
 	}
 
 	body .main {
-		margin: 45px 0 0 0;
+		margin: 100px 0 0 0;
 	}
 }
 

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -466,12 +466,16 @@ header {
 	}
 
 	.open-nav {
+		width: 25px;
+		height: 25px;
+		margin-left: 18px;
+
 		background-image: url(/images/menu.svg);
 		background-color: transparent;
 		background-repeat: no-repeat;
 		background-size: 100%;
 		border: 0;
-		position: absolute;
+		position: relative;
 		border-radius: 2px;
 		cursor: pointer;
 

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -95,6 +95,9 @@ h5 {
 
 p {
 	margin-top: 0;
+	img {
+		width: 100%;
+	}
 }
 
 h3 a {


### PR DESCRIPTION
Three things I discovered and fixed

1. Images overflow the content area when included via markdown (https://github.com/CloudCannon/aviator-jekyll-template/issues/7)
2. In the mobile Version the subheader blocks the first heading
3. The toggle icon for the mobile navigation was broken